### PR TITLE
Add basic dockerfile to serve build with static web server

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine as build
+RUN mkdir /app
+WORKDIR /app
+# Copy app into build container and build release
+COPY . .
+RUN npm install && npm run build
+
+FROM joseluisq/static-web-server:2-alpine
+# Add curl for health check
+RUN apk add --no-cache curl
+# Copy built app into static webserver container
+COPY --from=build /app/dist /public
+# Enable /health endpoint
+ENV SERVER_HEALTH=true
+# Set start period for quicker start check intervals of 5s
+HEALTHCHECK --start-period=30s --start-interval=5s CMD curl --fail http://localhost/health || exit 1

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
 FROM node:22-alpine as build
+# Ensure git is installed for baking version number
+RUN apk add --no-cache git
 RUN mkdir /app
 WORKDIR /app
 # Copy app into build container and build release


### PR DESCRIPTION
Hi, I hope you don't mind the unsolicited PR, but I was looking at hosting my own copy of this and thought you might want the basic docker file I put together for my own use.

It's very simple and just uses a node v22 container to build the dist folder then copies that to a static-web-server container and sets up the static-web-server /health endpoint.

There's not much reason I picked static-web-server other than it being one of the first results when I searched for high performance static file servers and when I saw that it mentioned being lightweight and safe (using rust) it seemed good enough, and it's simple to swap out if you have a preference for something else.

Let me know if I can help with any changes to make this more merge-able.

Notes:
* The `syntax=docker/dockerfile:1` is needed to prevent older docker installs from erroring when seeing `start-interval`
* The "install to homescreen" doesn't work since the start_url is hardcoded to briefsky.app, changing it to a relative url (`/?storage=local`) seems to make it work without hardcoding a domain.